### PR TITLE
Psr compat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,4 +77,4 @@ jobs:
 
       - run:
           name: Execute mutation testing
-          command: ./vendor/bin/infection --configuration=infection.json.dist --coverage=build/logs/coverage
+          command: ./vendor/bin/infection --configuration=infection.json.dist --coverage=build/logs/coverage --only-covered

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,9 @@
   "type": "library",
   "require": {
     "php": ">= 7.2",
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^6.3",
+    "psr/http-message": "^1.0",
+    "psr/http-client": "^1.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,9 @@
     "php": ">= 7.2",
     "guzzlehttp/guzzle": "^6.3",
     "psr/http-message": "^1.0",
-    "psr/http-client": "^1.0"
+    "psr/http-client": "^1.0",
+    "ricardofiorani/guzzle-psr18-adapter": "^1.0",
+    "psr/http-factory": "^1.0"
   },
   "autoload": {
     "psr-4": {
@@ -30,5 +32,17 @@
       "email": "dragonbe+github@gmail.com"
     }
   ],
-  "minimum-stability": "stable"
+  "minimum-stability": "stable",
+  "scripts": {
+    "check": [
+      "@cs-check",
+      "@test",
+      "@infection"
+    ],
+    "cs-check": "phpcs",
+    "cs-fix": "phpcbf",
+    "test": "phpunit --colors=always",
+    "test-coverage": "phpunit --colors=always --coverage-clover clover.xml",
+    "infection": "infection --only-covered"
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c19b2b959fe3c148eac9f4f0ecbe8e5f",
+    "content-hash": "f92dd5bec8f0701992a6e12390dbf559",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -237,6 +237,58 @@
             "time": "2018-10-30T23:29:13+00:00"
         },
         {
+            "name": "psr/http-factory",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "378bfe27931ecc54ff824a20d6f6bfc303bbd04c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/378bfe27931ecc54ff824a20d6f6bfc303bbd04c",
+                "reference": "378bfe27931ecc54ff824a20d6f6bfc303bbd04c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "time": "2018-07-30T21:54:04+00:00"
+        },
+        {
             "name": "psr/http-message",
             "version": "1.0.1",
             "source": {
@@ -285,6 +337,63 @@
                 "response"
             ],
             "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "ricardofiorani/guzzle-psr18-adapter",
+            "version": "v1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ricardofiorani/guzzle-psr18-adapter.git",
+                "reference": "380e1ee4a4efcfd31f5defd2f21217cc3def6f59"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ricardofiorani/guzzle-psr18-adapter/zipball/380e1ee4a4efcfd31f5defd2f21217cc3def6f59",
+                "reference": "380e1ee4a4efcfd31f5defd2f21217cc3def6f59",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^6.3",
+                "php": "^7.1",
+                "psr/http-client": "^1.0"
+            },
+            "provide": {
+                "psr/http-client": "^1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.3",
+                "spryker/code-sniffer": "^0.12.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "RicardoFiorani\\GuzzlePsr18Adapter\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ricardo Fiorani",
+                    "email": "ricardo.fiorani@gmail.com",
+                    "homepage": "https://github.com/ricardofiorani",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Guzzle PSR-18 adapter",
+            "homepage": "https://github.com/ricardofiorani/guzzle-psr18-adapter",
+            "keywords": [
+                "Guzzle",
+                "psr-18"
+            ],
+            "time": "2018-12-11T09:10:08+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c317ead1b5a78777df764d1d4a8c3b83",
+    "content-hash": "c19b2b959fe3c148eac9f4f0ecbe8e5f",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -186,6 +186,55 @@
                 "url"
             ],
             "time": "2017-03-20T17:10:46+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/496a823ef742b632934724bf769560c2a5c7c44e",
+                "reference": "496a823ef742b632934724bf769560c2a5c7c44e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "time": "2018-10-30T23:29:13+00:00"
         },
         {
             "name": "psr/http-message",

--- a/examples/hibp-count.php
+++ b/examples/hibp-count.php
@@ -1,8 +1,25 @@
 <?php
 
-require_once __DIR__ . '/vendor/autoload.php';
+namespace Hibp;
 
-$hibp = \Dragonbe\Hibp\HibpFactory::create();
+use Dragonbe\Hibp\Hibp;
+use Dragonbe\Hibp\HibpFactory;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/*
+ * This example shows how you can validate multiple passwords
+ * to the Have I been pwned API service.
+ *
+ * It also shows how you can retrieve the amount of times a
+ * given password was found in breaches.
+ */
+
+/**
+ * @var Hibp
+ */
+$hibp = HibpFactory::create();
+
 $passwords = ['password', 'NVt3MpvQ'];
 foreach ($passwords as $password) {
     $found = $hibp->isPwnedPassword($password);

--- a/examples/hibp-psr18.php
+++ b/examples/hibp-psr18.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Hibp;
+
+use Dragonbe\Hibp\Hibp;
+use Dragonbe\Hibp\HibpFactory;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RicardoFiorani\GuzzlePsr18Adapter\Client;
+
+require_once __DIR__ . '/../vendor/autoload.php';
+
+/*
+ * This example shows the usage of a PSR18 compliant
+ * HTTP class to make a call to the Have I been pwned
+ * API service.
+ *
+ * @see https://www.php-fig.org/psr/psr-18/
+ */
+/**
+ * @var ClientInterface
+ */
+$client = new Client(HibpFactory::createConfig());
+
+/**
+ * @var RequestInterface
+ */
+$request = new Request('GET', '/');
+
+/**
+ * @var ResponseInterface
+ */
+$response = new Response();
+
+/**
+ * @var Hibp
+ */
+$hibp = new Hibp($client, $request, $response);
+
+echo 'Password "password": ' . ($hibp->isPwnedPassword('password') ? 'Pwned' : 'OK') . PHP_EOL;
+echo 'Password "NVt3MpvQ": ' . ($hibp->isPwnedPassword('NVt3MpvQ') ? 'Pwned' : 'OK') . PHP_EOL;

--- a/examples/hibp.php
+++ b/examples/hibp.php
@@ -1,8 +1,22 @@
 <?php
 
+namespace Hibp;
+
+use Dragonbe\Hibp\Hibp;
+use Dragonbe\Hibp\HibpFactory;
+
 require_once __DIR__ . '/vendor/autoload.php';
 
-$hibp = \Dragonbe\Hibp\HibpFactory::create();
+/*
+ * This example shows how to quickly get started
+ * to make a call to the Have I been pwned API service.
+ */
+
+/**
+ * @var Hibp
+ */
+$hibp = HibpFactory::create();
+
 echo 'Password "password": ' . ($hibp->isPwnedPassword('password') ? 'Pwned' : 'OK') . PHP_EOL;
 echo 'Password "NVt3MpvQ": ' . ($hibp->isPwnedPassword('NVt3MpvQ') ? 'Pwned' : 'OK') . PHP_EOL;
 

--- a/src/Hibp.php
+++ b/src/Hibp.php
@@ -18,6 +18,7 @@ class Hibp implements HibpInterface, \Countable
     const HIBP_RANGE_LENGTH = 5;
     const HIBP_RANGE_BASE = 0;
     const HIBP_COUNT_BASE = 0;
+    const SHA1_LENGTH = 40;
 
     /**
      * @var ClientInterface
@@ -64,7 +65,7 @@ class Hibp implements HibpInterface, \Countable
         if (! $isShaHash) {
             $password = sha1($password);
         }
-        if (40 !== strlen($password) && $isShaHash) {
+        if (self::SHA1_LENGTH !== strlen($password) && $isShaHash) {
             throw new \InvalidArgumentException(
                 'Password does not appear to be a SHA1 hashed password, please verify your input'
             );
@@ -72,7 +73,8 @@ class Hibp implements HibpInterface, \Countable
         $password = strtoupper($password);
         $range = $this->getHashRange($password);
 
-        $request = new Request('GET', '/range/' . $range);
+        $requestClass = get_class($this->request);
+        $request = new $requestClass('GET', '/range/' . $range);
 
         try {
             $response = $this->client->sendRequest($request);

--- a/src/HibpFactory.php
+++ b/src/HibpFactory.php
@@ -25,6 +25,26 @@ class HibpFactory
     }
 
     /**
+     * Factory method to create a basic configuration with the
+     * option to provide your own settings to override default
+     * configuration options.
+     *
+     * @param array $config
+     * @return array
+     */
+    public static function createConfig(array $config = []): array
+    {
+        return array_replace_recursive([
+            'base_uri' => Hibp::HIBP_API_URI,
+            'timeout' => Hibp::HIBP_API_TIMEOUT,
+            'headers' => [
+                'User-Agent' => Hibp::HIBP_CLIENT_UA,
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ]
+        ], $config);
+    }
+
+    /**
      * Creates a real HTTP client for using in your applications
      * and make calls to the outside world.
      *
@@ -34,14 +54,7 @@ class HibpFactory
      */
     private static function createRealClient(array $config): Hibp
     {
-        $client = new Client(array_replace_recursive([
-            'base_uri' => Hibp::HIBP_API_URI,
-            'timeout' => Hibp::HIBP_API_TIMEOUT,
-            'headers' => [
-                'User-Agent' => Hibp::HIBP_CLIENT_UA,
-                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
-            ]
-        ], $config));
+        $client = new Client(self::createConfig($config));
         $request = new Request(
             'GET',
             Hibp::HIBP_API_URI,
@@ -69,11 +82,7 @@ class HibpFactory
         $client = new Client(['handler' => $handler]);
         $request = new Request(
             'GET',
-            Hibp::HIBP_API_URI,
-            [
-                'User-Agent' => Hibp::HIBP_CLIENT_UA,
-                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
-            ]
+            '/'
         );
         $response = new Response();
         return new Hibp($client, $request, $response);

--- a/src/HibpFactory.php
+++ b/src/HibpFactory.php
@@ -3,9 +3,11 @@ declare(strict_types=1);
 
 namespace Dragonbe\Hibp;
 
-use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use RicardoFiorani\GuzzlePsr18Adapter\Client;
 
 class HibpFactory
 {
@@ -40,7 +42,16 @@ class HibpFactory
                 'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
             ]
         ], $config));
-        return new Hibp($client);
+        $request = new Request(
+            'GET',
+            Hibp::HIBP_API_URI,
+            [
+                'User-Agent' => Hibp::HIBP_CLIENT_UA,
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ]
+        );
+        $response = new Response();
+        return new Hibp($client, $request, $response);
     }
 
     /**
@@ -56,6 +67,15 @@ class HibpFactory
         $mock = new MockHandler($mockArray);
         $handler = HandlerStack::create($mock);
         $client = new Client(['handler' => $handler]);
-        return new Hibp($client);
+        $request = new Request(
+            'GET',
+            Hibp::HIBP_API_URI,
+            [
+                'User-Agent' => Hibp::HIBP_CLIENT_UA,
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ]
+        );
+        $response = new Response();
+        return new Hibp($client, $request, $response);
     }
 }

--- a/src/HibpInterface.php
+++ b/src/HibpInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Dragonbe\Hibp;
+
+interface HibpInterface
+{
+    /**
+     * Checks a password against HIBP service and checks
+     * if the password is matching in the resultset
+     *
+     * @param string $password
+     * @param bool $isShaHash
+     * @return bool
+     */
+    public function isPwnedPassword(string $password, bool $isShaHash = false): bool;
+}

--- a/tests/HibpFactoryTest.php
+++ b/tests/HibpFactoryTest.php
@@ -6,6 +6,7 @@ namespace Dragonbe\Test\Hibp;
 use Dragonbe\Hibp\Hibp;
 use Dragonbe\Hibp\HibpFactory;
 use PHPUnit\Framework\TestCase;
+use PHPUnit\Runner\Version;
 
 class HibpFactoryTest extends TestCase
 {
@@ -33,5 +34,71 @@ class HibpFactoryTest extends TestCase
     {
         $hibp = HibpFactory::createTestClient();
         $this->assertInstanceOf(Hibp::class, $hibp);
+    }
+
+    /**
+     * Testing that we can generate our default configuration
+     * with expected results.
+     *
+     * @covers \Dragonbe\Hibp\HibpFactory::createConfig()
+     */
+    public function testFactoryCreationOfDefaultConfig()
+    {
+        $hibpConfig = HibpFactory::createConfig();
+        $expectedConfig = [
+            'base_uri' => Hibp::HIBP_API_URI,
+            'timeout' => Hibp::HIBP_API_TIMEOUT,
+            'headers' => [
+                'User-Agent' => Hibp::HIBP_CLIENT_UA,
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ]
+        ];
+        $this->assertSame($expectedConfig, $hibpConfig);
+    }
+
+    /**
+     * Testing that we can generate our custom configuration
+     * when providing different configuration settings
+     *
+     * @covers \Dragonbe\Hibp\HibpFactory::createConfig()
+     */
+    public function testFactoryCreationWithOverridingConfiguration()
+    {
+        $hibpConfig = HibpFactory::createConfig([
+            'timeout' => 250,
+            'headers' => [
+                'User-Agent' => 'phpunit/7.3.5',
+            ],
+        ]);
+        $expectedConfig = [
+            'base_uri' => Hibp::HIBP_API_URI,
+            'timeout' => 250,
+            'headers' => [
+                'User-Agent' => 'phpunit/7.3.5',
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ]
+        ];
+        $this->assertSame($expectedConfig, $hibpConfig);
+    }
+
+    /**
+     * Testing that we can add additional configuration settings
+     * by just providing the "new" configuration options.
+     *
+     * @covers \Dragonbe\Hibp\HibpFactory::createConfig()
+     */
+    public function testFactoryConfigAddsNotDefinedConfigurationOptions()
+    {
+        $hibpConfig = HibpFactory::createConfig(['foo' => 'bar']);
+        $expectedConfig = [
+            'base_uri' => Hibp::HIBP_API_URI,
+            'timeout' => Hibp::HIBP_API_TIMEOUT,
+            'headers' => [
+                'User-Agent' => Hibp::HIBP_CLIENT_UA,
+                'Accept' => Hibp::HIBP_CLIENT_ACCEPT,
+            ],
+            'foo' => 'bar',
+        ];
+        $this->assertSame($expectedConfig, $hibpConfig);
     }
 }


### PR DESCRIPTION
Fixes #10

Changes made in this pull request

I removed the hard dependency for a specific HTTP client (in our case GuzzleHttp) and implemented PSR 18 and PSR 7 to allow compliant clients to be used.

What were your challenges making this change (if any)?

PSR 18 is pretty new and there aren't many clients out there already implementing it fully.
